### PR TITLE
fix: another patch for avoiding crash on LoadLibrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 blur-plugins-core = { git = "https://github.com/tobii-dev/blur-plugins-core" }
 egui = "0.22.0"
 egui-d3d9 = "0.3.4"
-libloading = "0.8.0"
+#libloading = "0.8.0"
 log = { version = "0.4.20", features = ["release_max_level_info"] }
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 minhook-sys = "0.1.1"

--- a/src/api/blur_api.rs
+++ b/src/api/blur_api.rs
@@ -1,5 +1,4 @@
 use blur_plugins_core::{BlurAPI, BlurEvent, BlurPlugin, FnInit};
-use libloading::Symbol;
 use windows::{
 	s,
 	Win32::{Foundation::HMODULE, System::LibraryLoader::GetProcAddress},
@@ -29,9 +28,10 @@ impl MyBlurAPI {
 		true
 	}
 
+	/*
 	#[deprecated]
 	pub fn register_plugin_from_libloading_library(&mut self, lib: libloading::Library) -> bool {
-		let uwu: Result<Symbol<FnInit>, _> = unsafe { lib.get(b"plugin_init") };
+		let uwu: Result<libloading::Symbol<FnInit>, _> = unsafe { lib.get(b"plugin_init") };
 		match uwu {
 			Ok(loader_uwu) => {
 				let plugin = loader_uwu(self);
@@ -44,6 +44,7 @@ impl MyBlurAPI {
 			}
 		}
 	}
+	*/
 
 	fn register_plugin(&mut self, plugin: Box<dyn BlurPlugin>) {
 		self.plugins.push(plugin);

--- a/src/dll/f_direct3d9.rs
+++ b/src/dll/f_direct3d9.rs
@@ -57,6 +57,7 @@ unsafe extern "system" fn HOOK_EndScene(this: IDirect3DDevice9) -> HRESULT {
 	//let r = fn_EndScene(this);
 	//log::trace!("HOOK_EndScene!");
 	//r
+
 	fn_EndScene(this)
 }
 
@@ -112,8 +113,11 @@ unsafe extern "system" fn HOOK_Reset(
 
 impl MyD3D9 {
 	pub fn new(f: *mut IDirect3D9) -> Self {
-		crate::loader::dll_loader::load_dlls(); // FIXME: Are we sure that MyD3D9::new() only gets called once?
-
+		{
+			use std::sync::Once;
+			static START: Once = Once::new();
+			START.call_once(crate::loader::dll_loader::load_dlls);
+		}
 		let f = unsafe { IDirect3D9::from_raw(f as _) };
 		let r = MyD3D9 { f };
 		log::info!("MyD3D9::new() -> {r:#?}");


### PR DESCRIPTION
![dllmain_loadlibrary](https://github.com/tobii-dev/blur-hooks-rs/assets/77458451/6700104f-97b7-4185-8062-fed84a594e77)

![please-utf8](https://github.com/tobii-dev/blur-hooks-rs/assets/77458451/6945ef61-8a06-4ab5-b899-0e6af880c0ac)

windoze sux

